### PR TITLE
Add integration test using built package

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+let accessSecretVersionMock = vi.fn();
+vi.mock("@google-cloud/secret-manager", async () => {
+  const mod = await vi.importActual<any>("@google-cloud/secret-manager");
+  return {
+    ...mod,
+    SecretManagerServiceClient: vi.fn().mockImplementation(() => ({
+      accessSecretVersion: accessSecretVersionMock,
+    })),
+  };
+});
+
+describe("package integration", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retrieveSecret example works", async () => {
+    const { retrieveSecret } = await import("../dist/index.js");
+    const expected = "hello";
+    accessSecretVersionMock.mockResolvedValue([{ payload: { data: expected } }]);
+
+    const value = await retrieveSecret<string>("sm://my-project/my-secret");
+    expect(value).toEqual(expected);
+    expect(accessSecretVersionMock).toHaveBeenCalledWith({
+      name: "projects/my-project/secrets/my-secret/versions/latest",
+    });
+  });
+
+  it("resolveProcessEnv example works", async () => {
+    vi.stubEnv("MY_SECRET", "sm://another-project/another-secret");
+    vi.stubEnv("NOT_SECRET", "plain");
+    const { resolveProcessEnv } = await import("../dist/index.js");
+    const expected = "resolved";
+    accessSecretVersionMock.mockResolvedValue([{ payload: { data: expected } }]);
+
+    await resolveProcessEnv();
+
+    expect(process.env.MY_SECRET).toEqual(expected);
+    expect(process.env.NOT_SECRET).toEqual("plain");
+    expect(accessSecretVersionMock).toHaveBeenCalledWith({
+      name: "projects/another-project/secrets/another-secret/versions/latest",
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -104,5 +104,10 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "test",
+    "dist"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude test and dist files from build
- add integration test that uses built package and mocks Secret Manager

## Testing
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_685a363d7a188323b4b96d1bab8e15d9